### PR TITLE
希望将SwanLab集成为训练跟踪工具Integrate swanlab as experiments tracker!

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,26 @@ class DpoConfig:
     ...
 ```
 - 第二步，执行dpo_train
+
+### 开启训练看板
+
+可以通过SwanLab方便的查看训练日志变化，使用如下命令开启本地看板
+
+```bash
+swanlab watch
+```
+
 - 
 ### 模型对比
 因需要配合sft模型才能看差别，因为其本质是让sft的模型更好的对齐你的目标数据而已，min(Π，Π*);可以在下面的链接中下载对应dpo数据，和待优化的sft模型，链接如下：
 链接：https://pan.baidu.com/s/1GYeR6qrUhjsmpgh8-ABDpQ 
 提取码：dba9 
 
+<details style="color:rgb(128,128,128)">
 
+如果希望将训练过程保存在云端上查看，可以在callback调用处将`swanlab_callback = SwanLabCallback(...,mode="local")`的`mode`变量设置为`"cloud"`即可。
 
+</details>
 
 ## 🥇模型权重以及评测
 

--- a/dpo_train.py
+++ b/dpo_train.py
@@ -9,6 +9,7 @@ from datasets import Dataset, load_dataset
 from transformers import  TrainingArguments,DataCollatorForLanguageModeling
 from trl import DPOTrainer
 from peft import LoraConfig, TaskType, PeftModel
+from swanlab.integration.transformers import SwanLabCallback
 
 from qwen.modeling_qwen import QWenLMHeadModel
 from qwen.tokenization_qwen import QWenTokenizer
@@ -116,8 +117,9 @@ def train_dpo(config: DpoConfig, peft_config: LoraConfig=None) -> None:
         seed=config.seed,
         logging_dir=config.log_dir,
     )
-
+    swanlab_callback = SwanLabCallback(project="MINI_LLM-DPO",mode="cloud") # 添加训练跟踪callback
     # 7. 初始化 DPO trainer
+    
     dpo_trainer = DPOTrainer(
         model_train,
         model_ref,
@@ -132,7 +134,8 @@ def train_dpo(config: DpoConfig, peft_config: LoraConfig=None) -> None:
         max_prompt_length=config.max_seq_len,
         generate_during_eval=True,
         is_encoder_decoder=True,
-        # data_collator=data_collator
+        # data_collator=data_collator,
+        callbacks=[swanlab_callback]
     )
 
     # 8. 训练

--- a/dpo_train.py
+++ b/dpo_train.py
@@ -9,6 +9,7 @@ from datasets import Dataset, load_dataset
 from transformers import  TrainingArguments,DataCollatorForLanguageModeling
 from trl import DPOTrainer
 from peft import LoraConfig, TaskType, PeftModel
+from swanlab.integration.transformers import SwanLabCallback
 
 from qwen.modeling_qwen import QWenLMHeadModel
 from qwen.tokenization_qwen import QWenTokenizer
@@ -116,8 +117,9 @@ def train_dpo(config: DpoConfig, peft_config: LoraConfig=None) -> None:
         seed=config.seed,
         logging_dir=config.log_dir,
     )
-
+    swanlab_callback = SwanLabCallback(project="MINI_LLM-DPO",mode="local")    # 添加训练跟踪callback，如果想在线查看训练进展，可以指定mode="cloud"
     # 7. 初始化 DPO trainer
+    
     dpo_trainer = DPOTrainer(
         model_train,
         model_ref,
@@ -132,7 +134,8 @@ def train_dpo(config: DpoConfig, peft_config: LoraConfig=None) -> None:
         max_prompt_length=config.max_seq_len,
         generate_during_eval=True,
         is_encoder_decoder=True,
-        # data_collator=data_collator
+        # data_collator=data_collator,
+        callbacks=[swanlab_callback]
     )
 
     # 8. 训练

--- a/pre_train.py
+++ b/pre_train.py
@@ -18,6 +18,7 @@ from transformers import (
 from transformers.trainer_callback import TrainerControl, TrainerState
 
 from datasets import Dataset, load_dataset
+from swanlab.integration.transformers import SwanLabCallback
 from qwen.configuration_qwen import QWenConfig
 from qwen.modeling_qwen import QWenLMHeadModel
 from qwen.tokenization_qwen import QWenTokenizer
@@ -214,9 +215,10 @@ class MyTrainerCallback(TrainerCallback):
         control.should_save = True
         return control
 
-
+# 实例化训练callback
 my_trainer_callback = MyTrainerCallback()
-
+# 设置SwanLab训练跟踪工具
+swanlab_callback = SwanLabCallback(project="MINI_LLM-Pretrain",mode="cloud")    # 如果想使用本地模式，可以指定mode="local"
 # %% [markdown]
 # # 6. 定义训练参数
 
@@ -254,7 +256,7 @@ trainer = Trainer(
     data_collator=data_collator,
     train_dataset=train_dataset,
     eval_dataset=eval_dataset,
-    callbacks=[my_trainer_callback],
+    callbacks=[my_trainer_callback, swanlab_callback],
 )
 
 # %% [markdown]

--- a/pre_train.py
+++ b/pre_train.py
@@ -18,6 +18,7 @@ from transformers import (
 from transformers.trainer_callback import TrainerControl, TrainerState
 
 from datasets import Dataset, load_dataset
+from swanlab.integration.transformers import SwanLabCallback
 from qwen.configuration_qwen import QWenConfig
 from qwen.modeling_qwen import QWenLMHeadModel
 from qwen.tokenization_qwen import QWenTokenizer
@@ -214,9 +215,10 @@ class MyTrainerCallback(TrainerCallback):
         control.should_save = True
         return control
 
-
+# 实例化训练callback
 my_trainer_callback = MyTrainerCallback()
-
+# 设置SwanLab训练跟踪工具
+swanlab_callback = SwanLabCallback(project="MINI_LLM-Pretrain",mode="local")    # 如果想在线查看训练进展，可以指定mode="cloud"
 # %% [markdown]
 # # 6. 定义训练参数
 
@@ -254,7 +256,7 @@ trainer = Trainer(
     data_collator=data_collator,
     train_dataset=train_dataset,
     eval_dataset=eval_dataset,
-    callbacks=[my_trainer_callback],
+    callbacks=[my_trainer_callback, swanlab_callback],
 )
 
 # %% [markdown]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ einops==0.7.0
 flash-attn==2.5.5
 tiktoken
 einops
+swanlab==0.4.9


### PR DESCRIPTION
感谢 @jiahe7ay 大佬的优秀开源项目，最近正在研究轻量级模型的训练方案。获益匪浅！

希望在运行实验时能够通过SwanLab来进行训练日志的跟踪。我看到了项目中有使用tensorboard的记录。因此在集成中默认使用了[SwanLab的本地看板模式](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html)。如果大佬感兴趣也可以在`callback`处修改为默认云端看板模式，这样就可以随时随地包括用手机了解到最新的实验进展了！

目前SwanLab能够自动记录transformers框架的训练参数，我们也在积极推进与Transformers框架的官方集成。希望大佬能喜欢和支持下～

<img width="1667" alt="Screenshot 2025-03-01 at 19 04 35" src="https://github.com/user-attachments/assets/b1b98c50-2a1d-4f09-a9b0-2f2cde0604b1" />

本来想尝试一下跑实验，但是发现数据集比想象中要大，服务器得腾空间。等我下下来数据集后尝试运行下！也期待大佬放出实验结果帮助我们更好的复现实验。